### PR TITLE
Fix the one-line package description 

### DIFF
--- a/bm.el
+++ b/bm.el
@@ -1,4 +1,4 @@
-;;; bm.el  --- Visible bookmarks in buffer.
+;;; bm.el --- Visible bookmarks in buffer.
 
 ;; Copyrigth (C) 2000-2011  Jo Odland
 


### PR DESCRIPTION
so it can be found by Emacs's packaging mechanism, and thus show up properly
on the MELPA package repository (http://melpa.milkbox.net/).

The first line requires a single space between filename and the "---".
See the regexp near the top of package-buffer-info in package.el.
