### PR TITLE
 Auto remove bookmark after jump to it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GNU Emacs. I think they provide an easy way to navigate in a buffer.
 
 Features:
 ---------
+* Auto remove bookmark after jump to it by `bm-next` or `bm-previous`:
 * Cycle through bookmarks in all open buffers in LIFO order
 * Toggle bookmarks. Jump to next/previous bookmark.
 * Setting bookmarks based on a regexp. (Useful when searching logfiles.)
@@ -62,6 +63,13 @@ If you would like to cycle through bookmarks in *all* open buffers, add the foll
 
     (setq bm-cycle-all-buffers t)
 
+If you would like to remove bookmark after jump to it by `bm-next` or `bm-previous`:
+
+    (setq temporary-bookmark-p t)
+
+or if you want use this feature in your library:
+
+    (bm-bookmark-add nil nil t)
 
 
 Reviews and comments:

--- a/bm-tests.el
+++ b/bm-tests.el
@@ -63,3 +63,41 @@ This is the last line.")
       (bm-next)
       (should (bm-equal (bm-bookmark-at (point)) bookmark)))
     ))
+
+(ert-deftest bm-bookmark--bm-temporary-bookmark ()
+  (with-temp-buffer
+    (insert text)
+    (goto-line 2)
+    (bm-bookmark-add nil nil t)
+    (goto-line 5)
+    (bm-bookmark-add nil nil t)
+
+    (should (= (bm-count) 2))
+
+    (goto-char (point-min))
+    (bm-next)
+    (should (= (bm-count) 1))
+
+    (goto-char (point-min))
+    (bm-previous)
+    (should (= (bm-count) 0))
+    ))
+(ert-deftest bm-bookmark--option-bm-temporary-bookmark ()
+  (let ((temporary-bookmark-p t))
+    (with-temp-buffer
+      (insert text)
+      (goto-line 2)
+      (bm-bookmark-add)
+      (goto-line 5)
+      (bm-bookmark-add)
+
+      (should (= (bm-count) 2))
+
+      (goto-char (point-min))
+      (bm-next)
+      (should (= (bm-count) 1))
+
+      (goto-char (point-min))
+      (bm-previous)
+      (should (= (bm-count) 0)))
+    ))


### PR DESCRIPTION
add option `bm-auto-remove-after-jump' variable

add param remove-after-jump-p to function `bm-bookmark-add'
  (defun bm-bookmark-add (&optional annotation time remove-after-jump-p)

I write a function name goto-definition, I want use bm.el to set a marker before goto-definition 
so I can jump back use bm ,but I want to auto remove the bookmark after jump back 
so I open this pull request.

```
(defun goto-definition (&optional arg)
  "Make use of emacs' find-func and etags possibilities for finding definitions."
  (interactive "P")
    (bm-bookmark-add line nil t)
     ....
     ;; do something ...
```
