### PR TITLE
Fix typo in bm-sync.el and remove trailing whitespace

### DIFF
--- a/bm-sync.el
+++ b/bm-sync.el
@@ -26,7 +26,7 @@
 
 ;;; Description:
 ;;
-;; Create/remove a standard Emacs bookmark everytime you toggle a
+;; Create/remove a standard Emacs bookmark every time you toggle a
 ;; bm.el bookmark. This code is experimental.
 ;;
 ;; This code is related to a GitHub issue,
@@ -49,7 +49,7 @@
 (defun bm-bookmark-add--sync (&optional annotation time temporary-bookmark)
   "Add a standard Emacs bookmarks when setting a bm-bookmark."
   ;; create a unique name for the bookmark
-  (let ((name (concat (buffer-name)     
+  (let ((name (concat (buffer-name)
                       " l:" (int-to-string
                              (count-lines (point-min) (point))))))
     ;; store the bookmark name as an annotation


### PR DESCRIPTION
Here are are two trivial issues I found while preparing the Debian package.

Thank you very much for providing such nice self-tests!  I am particularly happy that it was possible to run the tests on the packages as-installed (after byte-compilation and dh-elpa magic) rather than only running them from the source dir.  If you'd like the link to Debian's continuous integration testing of bm.el please let me know and I'll share the URL as soon as the package is installed to the archive.

Sincerely,
Nicholas