### PR TITLE
Copy documentation of lazy-lock incompat from bm.el to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Features:
 * Cycle through bookmarks in all open buffers.
 
 
+Known Limitations:
+------------------
+
+There are some incompatibilities with lazy-lock when using
+fill-paragraph. All bookmark below the paragraph being filled will be
+lost. This issue can be resolved using the `jit-lock-mode'.
+
+
 Installation:
 -------------
 


### PR DESCRIPTION
Hi @joodland !

Previously I had included this documentation as a README.Debian, but a member of Emacsen team pointed out that this is an inappropriate use of README.Debian.  I'd like for incompatibilities to be more visibly documented than in the header of bm.el, so am filing this PR.  I didn't copy over the XEmacs and old versions of GNU Emacs stanzas, because I'm not sure if they're at a "front page of a project" level of relevancy.

Cheers,
Nicholas